### PR TITLE
Update real estate parameter schema integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-rest'
         implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.7'
+        implementation 'io.milvus:milvus-sdk-java:2.4.4'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 

--- a/src/main/java/org/garlikoff/restdata/config/MilvusConfiguration.java
+++ b/src/main/java/org/garlikoff/restdata/config/MilvusConfiguration.java
@@ -1,0 +1,30 @@
+package org.garlikoff.restdata.config;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.ConnectParam;
+import org.garlikoff.restdata.service.vector.TextEmbeddingService;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация клиента Milvus.
+ */
+@Configuration
+@EnableConfigurationProperties(MilvusProperties.class)
+public class MilvusConfiguration {
+
+    @Bean(destroyMethod = "close")
+    public MilvusServiceClient milvusServiceClient(MilvusProperties properties) {
+        ConnectParam connectParam = ConnectParam.newBuilder()
+                .withHost(properties.getHost())
+                .withPort(properties.getPort())
+                .build();
+        return new MilvusServiceClient(connectParam);
+    }
+
+    @Bean
+    public TextEmbeddingService textEmbeddingService(MilvusProperties properties) {
+        return new TextEmbeddingService(properties.getDimension());
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/config/MilvusProperties.java
+++ b/src/main/java/org/garlikoff/restdata/config/MilvusProperties.java
@@ -1,0 +1,39 @@
+package org.garlikoff.restdata.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Настройки подключения к Milvus, используемые для выгрузки векторных данных.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "milvus")
+public class MilvusProperties {
+
+    /**
+     * Хост Milvus.
+     */
+    private String host = "localhost";
+
+    /**
+     * Порт Milvus.
+     */
+    private int port = 19530;
+
+    /**
+     * Название коллекции, в которую выгружаются данные.
+     */
+    private String collectionName = "real_estate_objects";
+
+    /**
+     * Размерность векторного представления.
+     */
+    private int dimension = 128;
+
+    /**
+     * Создавать ли коллекцию автоматически, если она отсутствует.
+     */
+    private boolean autoCreateCollection = true;
+}

--- a/src/main/java/org/garlikoff/restdata/controller/RealEstateVectorController.java
+++ b/src/main/java/org/garlikoff/restdata/controller/RealEstateVectorController.java
@@ -1,0 +1,43 @@
+package org.garlikoff.restdata.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.garlikoff.restdata.service.vector.RealEstateVectorSearchResult;
+import org.garlikoff.restdata.service.vector.RealEstateVectorService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST контроллер для управления выгрузкой данных в Milvus и поиска.
+ */
+@RestController
+@RequestMapping("/api/v1/real-estate/vector")
+@RequiredArgsConstructor
+public class RealEstateVectorController {
+
+    private final RealEstateVectorService realEstateVectorService;
+
+    /**
+     * Выполняет полную синхронизацию объектов недвижимости с Milvus.
+     */
+    @PostMapping("/sync")
+    public ResponseEntity<Void> synchronize() {
+        realEstateVectorService.synchronizeAll();
+        return ResponseEntity.accepted().build();
+    }
+
+    /**
+     * Ищет объекты недвижимости по текстовому запросу.
+     */
+    @GetMapping("/search")
+    public ResponseEntity<List<RealEstateVectorSearchResult>> search(
+            @RequestParam("query") String query,
+            @RequestParam(value = "limit", defaultValue = "10") int limit) {
+        return ResponseEntity.ok(realEstateVectorService.search(query, limit));
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/model/RealEstateObjectParam.java
+++ b/src/main/java/org/garlikoff/restdata/model/RealEstateObjectParam.java
@@ -3,6 +3,8 @@ package org.garlikoff.restdata.model;
 import jakarta.persistence.*;
 import lombok.Data;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.UUID;
 
 /**
@@ -25,6 +27,12 @@ public class RealEstateObjectParam {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+    /**
+     * Объект недвижимости, с которым связаны параметры.
+     */
+    @ManyToOne
+    @JoinColumn(name = "real_estate_object_id")
+    private RealEstateObject realEstateObject;
     /**
      * Местоположение недвижимости.
      */
@@ -49,13 +57,19 @@ public class RealEstateObjectParam {
     /**
      * Тип жилья.
      */
-    @Column(name = "type")
-    private String type;
+    @ManyToOne
+    @JoinColumn(name = "type_of_accommodation_id")
+    private TypeOfAccommodation typeOfAccommodation;
     /**
      * Сведения о меблировке.
      */
     @Column(name = "furnishings")
     private String furnishings;
+    /**
+     * Описание объекта недвижимости.
+     */
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
     /**
      * Наличие лифта.
      */
@@ -91,6 +105,41 @@ public class RealEstateObjectParam {
      */
     @Column(name = "floor")
     private Integer floor;
+    /**
+     * Общее количество комнат.
+     */
+    @Column(name = "number_of_rooms")
+    private Integer numberOfRooms;
+    /**
+     * Стоимость аренды.
+     */
+    @Column(name = "price")
+    private BigDecimal price;
+    /**
+     * Валюта стоимости аренды.
+     */
+    @Column(name = "currency")
+    private String currency;
+    /**
+     * Размер депозита.
+     */
+    @Column(name = "deposit")
+    private BigDecimal deposit;
+    /**
+     * Дата, с которой доступен объект.
+     */
+    @Column(name = "available_from")
+    private LocalDate availableFrom;
+    /**
+     * Разрешены ли дети.
+     */
+    @Column(name = "children_allowed")
+    private Boolean childrenAllowed;
+    /**
+     * Разрешены ли домашние животные.
+     */
+    @Column(name = "pets_allowed")
+    private Boolean petsAllowed;
     /**
      * Указывает на наличие кондиционера.
      */

--- a/src/main/java/org/garlikoff/restdata/service/vector/RealEstateVectorSearchResult.java
+++ b/src/main/java/org/garlikoff/restdata/service/vector/RealEstateVectorSearchResult.java
@@ -1,0 +1,21 @@
+package org.garlikoff.restdata.service.vector;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Результат поиска по объектам недвижимости в Milvus.
+ */
+@Value
+@Builder
+public class RealEstateVectorSearchResult {
+    String vectorId;
+    UUID entityId;
+    String entityType;
+    double score;
+    String summary;
+    Map<String, Object> details;
+}

--- a/src/main/java/org/garlikoff/restdata/service/vector/RealEstateVectorService.java
+++ b/src/main/java/org/garlikoff/restdata/service/vector/RealEstateVectorService.java
@@ -1,0 +1,424 @@
+package org.garlikoff.restdata.service.vector;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.common.clientenum.ConsistencyLevelEnum;
+import io.milvus.exception.MilvusException;
+import io.milvus.grpc.SearchResults;
+import io.milvus.param.*;
+import io.milvus.param.collection.CreateCollectionParam;
+import io.milvus.param.collection.DropCollectionParam;
+import io.milvus.param.collection.FieldType;
+import io.milvus.param.collection.HasCollectionParam;
+import io.milvus.param.collection.LoadCollectionParam;
+import io.milvus.param.collection.ReleaseCollectionParam;
+import io.milvus.param.collection.FlushParam;
+import io.milvus.param.dml.InsertParam;
+import io.milvus.param.dml.SearchParam;
+import io.milvus.param.metric.MetricType;
+import io.milvus.response.R;
+import io.milvus.response.SearchResultsWrapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.garlikoff.restdata.config.MilvusProperties;
+import org.garlikoff.restdata.model.Location;
+import org.garlikoff.restdata.model.RealEstateObject;
+import org.garlikoff.restdata.model.RealEstateObjectParam;
+import org.garlikoff.restdata.model.TypeOfAccommodation;
+import org.garlikoff.restdata.repo.RealEstateObjectParamRepository;
+import org.garlikoff.restdata.repo.RealEstateObjectRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Сервис для выгрузки и поиска объектов недвижимости в Milvus.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RealEstateVectorService {
+
+    private static final String PRIMARY_FIELD = "vector_id";
+    private static final String VECTOR_FIELD = "embedding";
+    private static final String ENTITY_ID_FIELD = "entity_id";
+    private static final String ENTITY_TYPE_FIELD = "entity_type";
+    private static final String SUMMARY_FIELD = "summary";
+
+    private final MilvusServiceClient milvusClient;
+    private final MilvusProperties properties;
+    private final TextEmbeddingService embeddingService;
+    private final RealEstateObjectRepository realEstateObjectRepository;
+    private final RealEstateObjectParamRepository realEstateObjectParamRepository;
+
+    @PostConstruct
+    public void ensureCollectionExists() {
+        if (!properties.isAutoCreateCollection()) {
+            return;
+        }
+        try {
+            boolean hasCollection = Boolean.TRUE.equals(milvusClient.hasCollection(
+                    HasCollectionParam.newBuilder().withCollectionName(properties.getCollectionName()).build()).getData());
+            if (!hasCollection) {
+                log.info("Milvus collection '{}' not found. Creating...", properties.getCollectionName());
+                createCollection();
+            }
+        } catch (MilvusException e) {
+            throw new IllegalStateException("Failed to initialize Milvus collection", e);
+        }
+    }
+
+    /**
+     * Полностью пересобирает коллекцию Milvus из актуальных данных базы.
+     */
+    @Transactional(readOnly = true)
+    public synchronized void synchronizeAll() {
+        dropCollectionIfExists();
+        createCollection();
+
+        List<String> vectorIds = new ArrayList<>();
+        List<List<Float>> embeddings = new ArrayList<>();
+        List<String> entityIds = new ArrayList<>();
+        List<String> entityTypes = new ArrayList<>();
+        List<String> summaries = new ArrayList<>();
+
+        realEstateObjectRepository.findAll().forEach(object -> {
+            String summary = buildObjectSummary(object);
+            vectorIds.add("object:" + object.getId());
+            embeddings.add(embeddingService.embed(summary));
+            entityIds.add(object.getId() != null ? object.getId().toString() : "");
+            entityTypes.add("REAL_ESTATE_OBJECT");
+            summaries.add(summary);
+        });
+
+        realEstateObjectParamRepository.findAll().forEach(param -> {
+            String summary = buildParamSummary(param);
+            vectorIds.add("param:" + param.getId());
+            embeddings.add(embeddingService.embed(summary));
+            entityIds.add(param.getId() != null ? param.getId().toString() : "");
+            entityTypes.add("REAL_ESTATE_OBJECT_PARAM");
+            summaries.add(summary);
+        });
+
+        if (vectorIds.isEmpty()) {
+            log.info("No real estate data found for synchronization with Milvus.");
+            return;
+        }
+
+        List<InsertParam.Field> fields = List.of(
+                new InsertParam.Field(PRIMARY_FIELD, vectorIds),
+                new InsertParam.Field(VECTOR_FIELD, embeddings),
+                new InsertParam.Field(ENTITY_ID_FIELD, entityIds),
+                new InsertParam.Field(ENTITY_TYPE_FIELD, entityTypes),
+                new InsertParam.Field(SUMMARY_FIELD, summaries)
+        );
+
+        InsertParam insertParam = InsertParam.newBuilder()
+                .withCollectionName(properties.getCollectionName())
+                .withFields(fields)
+                .build();
+
+        milvusClient.insert(insertParam);
+        milvusClient.flush(FlushParam.newBuilder()
+                .withCollectionNames(Collections.singletonList(properties.getCollectionName()))
+                .build());
+        log.info("Synchronized {} records with Milvus collection {}", vectorIds.size(), properties.getCollectionName());
+    }
+
+    /**
+     * Выполняет поиск по текстовому запросу среди объектов недвижимости.
+     *
+     * @param query строка запроса
+     * @param limit максимальное количество результатов
+     * @return список результатов поиска
+     */
+    public List<RealEstateVectorSearchResult> search(String query, int limit) {
+        if (!StringUtils.hasText(query)) {
+            return Collections.emptyList();
+        }
+
+        loadCollection();
+
+        SearchParam searchParam = SearchParam.newBuilder()
+                .withCollectionName(properties.getCollectionName())
+                .withMetricType(MetricType.L2)
+                .withOutFields(List.of(PRIMARY_FIELD, ENTITY_ID_FIELD, ENTITY_TYPE_FIELD, SUMMARY_FIELD))
+                .withTopK(limit)
+                .withVectors(Collections.singletonList(embeddingService.embed(query)))
+                .withVectorFieldName(VECTOR_FIELD)
+                .withConsistencyLevel(ConsistencyLevelEnum.BOUNDED)
+                .build();
+
+        R<SearchResults> result = milvusClient.search(searchParam);
+        if (result.getData() == null) {
+            return Collections.emptyList();
+        }
+        SearchResultsWrapper wrapper = new SearchResultsWrapper(result.getData().getResults());
+
+        List<SearchResultsWrapper.IDScore> scores = wrapper.getIDScore(0);
+        List<?> entityIdField = wrapper.getFieldData(ENTITY_ID_FIELD, 0);
+        List<?> entityTypeField = wrapper.getFieldData(ENTITY_TYPE_FIELD, 0);
+        List<?> summaryField = wrapper.getFieldData(SUMMARY_FIELD, 0);
+
+        List<RealEstateVectorSearchResult> responses = new ArrayList<>();
+        for (int i = 0; i < scores.size(); i++) {
+            SearchResultsWrapper.IDScore score = scores.get(i);
+            String entityIdValue = entityIdField != null && entityIdField.size() > i ? (String) entityIdField.get(i) : null;
+            String entityTypeValue = entityTypeField != null && entityTypeField.size() > i ? (String) entityTypeField.get(i) : null;
+            String summaryValue = summaryField != null && summaryField.size() > i ? (String) summaryField.get(i) : null;
+            UUID entityUuid = parseUuid(entityIdValue);
+            responses.add(buildResult(score.getStrID(), entityUuid, entityTypeValue, score.getScore(), summaryValue));
+        }
+        return responses;
+    }
+
+    private RealEstateVectorSearchResult buildResult(String vectorId, UUID entityUuid, String entityType,
+                                                     double score, String summary) {
+        RealEstateVectorSearchResult.RealEstateVectorSearchResultBuilder builder = RealEstateVectorSearchResult.builder()
+                .vectorId(vectorId)
+                .entityType(entityType)
+                .score(score)
+                .summary(summary);
+        if (entityUuid != null) {
+            builder.entityId(entityUuid);
+            if ("REAL_ESTATE_OBJECT".equals(entityType)) {
+                realEstateObjectRepository.findById(entityUuid)
+                        .ifPresent(object -> builder.details(Collections.singletonMap("userId",
+                                object.getUser() != null ? object.getUser().getId() : null)));
+            } else if ("REAL_ESTATE_OBJECT_PARAM".equals(entityType)) {
+                realEstateObjectParamRepository.findById(entityUuid)
+                        .ifPresent(param -> builder.details(buildParamDetails(param)));
+            }
+        }
+        return builder.build();
+    }
+
+    private UUID parseUuid(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException ex) {
+            log.warn("Unable to parse UUID '{}' returned by Milvus", value);
+            return null;
+        }
+    }
+
+    private void loadCollection() {
+        try {
+            milvusClient.loadCollection(LoadCollectionParam.newBuilder()
+                    .withCollectionName(properties.getCollectionName())
+                    .build());
+        } catch (MilvusException e) {
+            throw new IllegalStateException("Failed to load Milvus collection", e);
+        }
+    }
+
+    private void dropCollectionIfExists() {
+        try {
+            boolean hasCollection = Boolean.TRUE.equals(milvusClient.hasCollection(HasCollectionParam.newBuilder()
+                    .withCollectionName(properties.getCollectionName()).build()).getData());
+            if (hasCollection) {
+                milvusClient.releaseCollection(ReleaseCollectionParam.newBuilder()
+                        .withCollectionName(properties.getCollectionName())
+                        .build());
+                milvusClient.dropCollection(DropCollectionParam.newBuilder()
+                        .withCollectionName(properties.getCollectionName())
+                        .build());
+            }
+        } catch (MilvusException e) {
+            throw new IllegalStateException("Failed to drop Milvus collection", e);
+        }
+    }
+
+    private void createCollection() {
+        FieldType vectorIdField = FieldType.newBuilder()
+                .withName(PRIMARY_FIELD)
+                .withDataType(DataType.VarChar)
+                .withMaxLength(128)
+                .withPrimaryKey(true)
+                .withAutoID(false)
+                .build();
+
+        FieldType vectorField = FieldType.newBuilder()
+                .withName(VECTOR_FIELD)
+                .withDataType(DataType.FloatVector)
+                .withDimension(properties.getDimension())
+                .build();
+
+        FieldType entityIdField = FieldType.newBuilder()
+                .withName(ENTITY_ID_FIELD)
+                .withDataType(DataType.VarChar)
+                .withMaxLength(64)
+                .build();
+
+        FieldType entityTypeField = FieldType.newBuilder()
+                .withName(ENTITY_TYPE_FIELD)
+                .withDataType(DataType.VarChar)
+                .withMaxLength(64)
+                .build();
+
+        FieldType summaryField = FieldType.newBuilder()
+                .withName(SUMMARY_FIELD)
+                .withDataType(DataType.VarChar)
+                .withMaxLength(2048)
+                .build();
+
+        CreateCollectionParam createCollectionParam = CreateCollectionParam.newBuilder()
+                .withCollectionName(properties.getCollectionName())
+                .withFieldTypes(List.of(vectorIdField, vectorField, entityIdField, entityTypeField, summaryField))
+                .build();
+        try {
+            milvusClient.createCollection(createCollectionParam);
+        } catch (MilvusException e) {
+            throw new IllegalStateException("Failed to create Milvus collection", e);
+        }
+    }
+
+    private String buildObjectSummary(RealEstateObject object) {
+        StringBuilder summary = new StringBuilder("Real estate object");
+        if (object.getUser() != null && object.getUser().getId() != null) {
+            summary.append(" owned by user ").append(object.getUser().getId());
+        }
+        return summary.toString();
+    }
+
+    private String buildParamSummary(RealEstateObjectParam param) {
+        StringBuilder summary = new StringBuilder("Real estate details");
+        appendIfNotNull(summary, " area", formatNumber(param.getArea()))
+                .append(parameterValue(" bedrooms", param.getNumberOfBedrooms()))
+                .append(parameterValue(" bathrooms", param.getNumberOfBathrooms()))
+                .append(parameterValue(" floor", param.getFloor()))
+                .append(parameterValue(" rooms", param.getNumberOfRooms()))
+                .append(parameterValue(" furnishings", param.getFurnishings()))
+                .append(booleanParameter(" elevator", param.getElevator()))
+                .append(booleanParameter(" balcony", param.getBalcony()))
+                .append(booleanParameter(" garage", param.getGarage()))
+                .append(booleanParameter(" courtyard", param.getCourtyard()))
+                .append(booleanParameter(" pool", param.getPool()))
+                .append(booleanParameter(" storeroom", param.getStoreroom()))
+                .append(booleanParameter(" air conditioner", param.getAirConditioner()))
+                .append(booleanParameter(" children", param.getChildrenAllowed()))
+                .append(booleanParameter(" pets", param.getPetsAllowed()));
+        if (param.getTypeOfAccommodation() != null) {
+            TypeOfAccommodation type = param.getTypeOfAccommodation();
+            if (StringUtils.hasText(type.getName())) {
+                summary.append(" type ").append(type.getName());
+            }
+        }
+        if (param.getLocation() != null) {
+            Location location = param.getLocation();
+            summary.append(" location ").append(location.getNameKey());
+            if (StringUtils.hasText(location.getType())) {
+                summary.append(" type ").append(location.getType());
+            }
+        }
+        if (param.getRealEstateObject() != null && param.getRealEstateObject().getId() != null) {
+            summary.append(" object ").append(param.getRealEstateObject().getId());
+        }
+        appendIfNotNull(summary, " price", formatMoney(param.getPrice(), param.getCurrency()));
+        appendIfNotNull(summary, " deposit", formatMoney(param.getDeposit(), param.getCurrency()));
+        appendIfNotNull(summary, " available from", formatLocalDate(param.getAvailableFrom()));
+        appendIfNotNull(summary, " description", shorten(param.getDescription(), 120));
+        return summary.toString();
+    }
+
+    private StringBuilder appendIfNotNull(StringBuilder builder, String label, String value) {
+        if (value != null) {
+            builder.append(label).append(' ').append(value);
+        }
+        return builder;
+    }
+
+    private String parameterValue(String label, Number value) {
+        if (value == null) {
+            return "";
+        }
+        return label + " " + value;
+    }
+
+    private String parameterValue(String label, String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        return label + " " + value;
+    }
+
+    private String booleanParameter(String label, Boolean value) {
+        if (value == null) {
+            return "";
+        }
+        return label + (Boolean.TRUE.equals(value) ? " yes" : " no");
+    }
+
+    private String formatMoney(java.math.BigDecimal value, String currency) {
+        if (value == null) {
+            return null;
+        }
+        String amount = value.stripTrailingZeros().toPlainString();
+        if (StringUtils.hasText(currency)) {
+            return amount + " " + currency;
+        }
+        return amount;
+    }
+
+    private String formatLocalDate(java.time.LocalDate date) {
+        if (date == null) {
+            return null;
+        }
+        return date.toString();
+    }
+
+    private String shorten(String text, int maxLength) {
+        if (!StringUtils.hasText(text)) {
+            return null;
+        }
+        String trimmed = text.trim();
+        if (trimmed.length() <= maxLength) {
+            return trimmed;
+        }
+        return trimmed.substring(0, maxLength) + "…";
+    }
+
+    private String formatNumber(Double value) {
+        if (value == null) {
+            return null;
+        }
+        return String.format(Locale.ROOT, "%.2f", value);
+    }
+
+    private java.util.Map<String, Object> buildParamDetails(RealEstateObjectParam param) {
+        java.util.Map<String, Object> details = new java.util.HashMap<>();
+        if (param.getRealEstateObject() != null) {
+            details.put("realEstateObjectId", param.getRealEstateObject().getId());
+        }
+        details.put("area", param.getArea());
+        details.put("bedrooms", param.getNumberOfBedrooms());
+        details.put("bathrooms", param.getNumberOfBathrooms());
+        if (param.getTypeOfAccommodation() != null) {
+            details.put("typeOfAccommodationId", param.getTypeOfAccommodation().getId());
+            details.put("typeOfAccommodation", param.getTypeOfAccommodation().getName());
+        }
+        details.put("furnishings", param.getFurnishings());
+        details.put("rooms", param.getNumberOfRooms());
+        details.put("price", param.getPrice());
+        details.put("currency", param.getCurrency());
+        details.put("deposit", param.getDeposit());
+        details.put("availableFrom", param.getAvailableFrom());
+        details.put("childrenAllowed", param.getChildrenAllowed());
+        details.put("petsAllowed", param.getPetsAllowed());
+        details.put("description", param.getDescription());
+        if (param.getLocation() != null) {
+            details.put("location", param.getLocation().getNameKey());
+            details.put("locationId", param.getLocation().getId());
+        }
+        return details;
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/service/vector/TextEmbeddingService.java
+++ b/src/main/java/org/garlikoff/restdata/service/vector/TextEmbeddingService.java
@@ -1,0 +1,63 @@
+package org.garlikoff.restdata.service.vector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.StringTokenizer;
+
+/**
+ * Простейший сервис построения векторных представлений текста.
+ * <p>
+ * В реальной системе вместо него следует использовать сервис эмбеддингов
+ * (например, OpenAI, HuggingFace и т.д.). Данный вариант обеспечивает
+ * детерминированный результат, что позволяет интегрировать Milvus даже без
+ * внешних зависимостей.
+ */
+public class TextEmbeddingService {
+
+    private final int dimension;
+
+    public TextEmbeddingService(int dimension) {
+        this.dimension = dimension;
+    }
+
+    /**
+     * Строит простое векторное представление текста на основе счётчиков токенов.
+     *
+     * @param text текст для кодирования
+     * @return вектор фиксированной размерности
+     */
+    public List<Float> embed(String text) {
+        float[] vector = new float[dimension];
+        if (text != null && !text.isBlank()) {
+            String normalized = text.toLowerCase(Locale.ROOT);
+            StringTokenizer tokenizer = new StringTokenizer(normalized, " ,.;:\n\t\r!?()[]{}<>-_");
+            while (tokenizer.hasMoreTokens()) {
+                String token = tokenizer.nextToken();
+                int index = Math.floorMod(Objects.hash(token), dimension);
+                vector[index] += 1.0f;
+            }
+            normalize(vector);
+        }
+        List<Float> result = new ArrayList<>(dimension);
+        for (float value : vector) {
+            result.add(value);
+        }
+        return result;
+    }
+
+    private void normalize(float[] vector) {
+        double sumSquares = 0.0;
+        for (float value : vector) {
+            sumSquares += value * value;
+        }
+        if (sumSquares <= 0.0) {
+            return;
+        }
+        double norm = Math.sqrt(sumSquares);
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] = (float) (vector[i] / norm);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,3 +57,8 @@ management:
 logging:
   level:
     org.springframework.security: DEBUG
+milvus:
+  host: localhost
+  port: 19530
+  collection-name: real_estate_objects
+  dimension: 128

--- a/src/main/resources/liquibase/changes/03-update-real-estate-object-param.xml
+++ b/src/main/resources/liquibase/changes/03-update-real-estate-object-param.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="3" author="codex">
+        <dropForeignKeyConstraint constraintName="real_estate_object_param_word_fk"
+                                   baseTableName="real_estate_object_param"/>
+        <dropColumn tableName="real_estate_object_param" columnName="type"/>
+
+        <addColumn tableName="real_estate_object_param">
+            <column name="real_estate_object_id" type="UUID"/>
+            <column name="type_of_accommodation_id" type="UUID"/>
+            <column name="description" type="TEXT"/>
+            <column name="number_of_rooms" type="INT"/>
+            <column name="price" type="NUMERIC"/>
+            <column name="currency" type="VARCHAR(3)"/>
+            <column name="deposit" type="NUMERIC"/>
+            <column name="available_from" type="DATE"/>
+            <column name="children_allowed" type="BOOLEAN"/>
+            <column name="pets_allowed" type="BOOLEAN"/>
+        </addColumn>
+
+        <addForeignKeyConstraint baseTableName="real_estate_object_param"
+                                 baseColumnNames="real_estate_object_id"
+                                 referencedTableName="real_estate_object"
+                                 referencedColumnNames="id"
+                                 constraintName="real_estate_object_param_object_fk"/>
+
+        <addForeignKeyConstraint baseTableName="real_estate_object_param"
+                                 baseColumnNames="type_of_accommodation_id"
+                                 referencedTableName="type_of_accommodation"
+                                 referencedColumnNames="id"
+                                 constraintName="real_estate_object_param_type_fk"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/db.changelog-master.xml
+++ b/src/main/resources/liquibase/db.changelog-master.xml
@@ -6,5 +6,6 @@
 
     <include file="changes/01-create-tables.xml" relativeToChangelogFile="true"/>
     <include file="changes/02-load-locations.xml" relativeToChangelogFile="true"/>
+    <include file="changes/03-update-real-estate-object-param.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- align the `RealEstateObjectParam` JPA model with the latest schema, including links to real estate objects, accommodation types, and new pricing/availability fields
- add a Liquibase change set to migrate the database structure and register it in the changelog master
- update the Milvus synchronization/search logic to embed and return the enriched parameter information

## Testing
- ./gradlew test *(fails: missing Java 17 toolchain in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a2390c8c832d8577afc3a3264c7a