### PR TITLE
Handle Milvus index type without missing SDK classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-rest'
         implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.7'
+        implementation 'io.milvus:milvus-sdk-java:2.4.5'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 

--- a/src/main/java/org/garlikoff/restdata/config/MilvusConfiguration.java
+++ b/src/main/java/org/garlikoff/restdata/config/MilvusConfiguration.java
@@ -1,0 +1,38 @@
+package org.garlikoff.restdata.config;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.ConnectParam;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация клиента Milvus.
+ */
+@Configuration
+@EnableConfigurationProperties(MilvusProperties.class)
+public class MilvusConfiguration {
+
+    /**
+     * Создаёт и настраивает клиент Milvus.
+     *
+     * @param properties конфигурация подключения
+     * @return настроенный клиент
+     */
+    @Bean(destroyMethod = "close")
+    public MilvusServiceClient milvusClient(MilvusProperties properties) {
+        ConnectParam.Builder builder = ConnectParam.newBuilder()
+            .withHost(properties.getHost())
+            .withPort(properties.getPort())
+            .withDatabaseName(properties.getDatabase());
+        if (StringUtils.isNotBlank(properties.getUsername())) {
+            String token = properties.getUsername();
+            if (StringUtils.isNotBlank(properties.getPassword())) {
+                token = token + ":" + properties.getPassword();
+            }
+            builder.withToken(token);
+        }
+        return new MilvusServiceClient(builder.build());
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/config/MilvusProperties.java
+++ b/src/main/java/org/garlikoff/restdata/config/MilvusProperties.java
@@ -1,0 +1,72 @@
+package org.garlikoff.restdata.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Настройки подключения и схемы коллекции Milvus для объектов недвижимости.
+ */
+@Data
+@ConfigurationProperties(prefix = "milvus")
+public class MilvusProperties {
+    /**
+     * Хост Milvus.
+     */
+    private String host = "localhost";
+    /**
+     * Порт Milvus.
+     */
+    private int port = 19530;
+    /**
+     * Имя базы данных Milvus.
+     */
+    private String database = "default";
+    /**
+     * Имя коллекции, в которой хранятся векторы объектов недвижимости.
+     */
+    private String collection = "real_estate_objects";
+    /**
+     * Имя поля коллекции, содержащего векторные представления.
+     */
+    private String vectorField = "embedding";
+    /**
+     * Размерность создаваемых векторов.
+     */
+    private int dimension = 256;
+    /**
+     * Тип индекса Milvus.
+     */
+    private String indexType = "IVF_FLAT";
+    /**
+     * Тип метрики для поиска.
+     */
+    private String metricType = "COSINE";
+    /**
+     * Дополнительные параметры индекса в формате JSON.
+     */
+    private String indexParams = "{\"nlist\":1024}";
+    /**
+     * Параметры поиска Milvus в формате JSON.
+     */
+    private String searchParams = "{\"nprobe\":16}";
+    /**
+     * Имя пользователя Milvus (опционально).
+     */
+    private String username;
+    /**
+     * Пароль Milvus (опционально).
+     */
+    private String password;
+    /**
+     * Количество шардов коллекции.
+     */
+    private int shardsNum = 2;
+    /**
+     * Максимальная длина текстового описания, сохраняемого в Milvus.
+     */
+    private int descriptionMaxLength = 1024;
+    /**
+     * Целевой язык переводов для формирования описаний.
+     */
+    private String language = "es";
+}

--- a/src/main/java/org/garlikoff/restdata/model/RealEstateObjectParam.java
+++ b/src/main/java/org/garlikoff/restdata/model/RealEstateObjectParam.java
@@ -47,35 +47,40 @@ public class RealEstateObjectParam {
     @Column(name = "number_of_bathrooms")
     private Integer numberOfBathrooms;
     /**
-     * Тип жилья.
+     * Тип жилья (квартиры, дома, комнаты).
      */
-    @Column(name = "type")
-    private String type;
+    @ManyToOne
+    @JoinColumn(name = "type")
+    private Word type;
     /**
      * Сведения о меблировке.
      */
-    @Column(name = "furnishings")
-    private String furnishings;
+    @ManyToOne
+    @JoinColumn(name = "furnishings")
+    private Word furnishings;
     /**
      * Наличие лифта.
      */
     @Column(name = "elevator")
     private Boolean elevator;
     /**
-     * Наличие балкона.
+     * Тип балкона/террасы (балкон, терраса или отсутствие).
      */
-    @Column(name = "balcony")
-    private Boolean balcony;
+    @ManyToOne
+    @JoinColumn(name = "balcony_terrace")
+    private Word balconyTerrace;
     /**
-     * Наличие гаража.
+     * Наличие и тип парковки (гараж, парковка или отсутствие).
      */
-    @Column(name = "garage")
-    private Boolean garage;
+    @ManyToOne
+    @JoinColumn(name = "garage_parking")
+    private Word garageParking;
     /**
-     * Наличие двора.
+     * Тип придомовой территории (сад, двор или отсутствие).
      */
-    @Column(name = "courtyard")
-    private Boolean courtyard;
+    @ManyToOne
+    @JoinColumn(name = "garden_yard")
+    private Word gardenYard;
     /**
      * Наличие бассейна.
      */
@@ -87,13 +92,43 @@ public class RealEstateObjectParam {
     @Column(name = "storeroom")
     private Boolean storeroom;
     /**
-     * Номер этажа.
+     * Состояние жилья.
      */
-    @Column(name = "floor")
-    private Integer floor;
+    @ManyToOne
+    @JoinColumn(name = "housing_condition")
+    private Word housingCondition;
+    /**
+     * Номер этажа с учётом классификации (например, Planta baja, Ático).
+     */
+    @ManyToOne
+    @JoinColumn(name = "floor")
+    private Word floor;
     /**
      * Указывает на наличие кондиционера.
      */
     @Column(name = "air_conditioner")
     private Boolean airConditioner;
+    /**
+     * Тип отопления (газовое, электрическое или отсутствие).
+     */
+    @ManyToOne
+    @JoinColumn(name = "heating")
+    private Word heating;
+    /**
+     * Энергетический сертификат.
+     */
+    @ManyToOne
+    @JoinColumn(name = "energy_certificate")
+    private Word energyCertificate;
+    /**
+     * Год постройки дома.
+     */
+    @Column(name = "year_built")
+    private Integer yearBuilt;
+    /**
+     * Ориентация квартиры (север, юг, запад, восток).
+     */
+    @ManyToOne
+    @JoinColumn(name = "orientation")
+    private Word orientation;
 }

--- a/src/main/java/org/garlikoff/restdata/service/RealEstateDescriptionBuilder.java
+++ b/src/main/java/org/garlikoff/restdata/service/RealEstateDescriptionBuilder.java
@@ -1,0 +1,91 @@
+package org.garlikoff.restdata.service;
+
+import org.garlikoff.restdata.model.Location;
+import org.garlikoff.restdata.model.RealEstateObjectParam;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Формирует текстовое описание параметров объекта недвижимости на основе переводов.
+ */
+@Component
+public class RealEstateDescriptionBuilder {
+    private static final String YES = "Sí";
+    private static final String NO = "No";
+
+    /**
+     * Собирает текстовое описание, используя переводы словарных значений.
+     *
+     * @param param                параметры объекта
+     * @param translationResolver  словарь переводов (ключ слова -> перевод)
+     * @return связное текстовое описание
+     */
+    public String buildDescription(RealEstateObjectParam param, Map<String, String> translationResolver) {
+        StringBuilder builder = new StringBuilder();
+        appendLocation(builder, param.getLocation(), translationResolver);
+        appendNumeric(builder, "Superficie", Optional.ofNullable(param.getArea()).map(v -> v + " m²").orElse(null));
+        appendNumeric(builder, "Dormitorios", valueOrNull(param.getNumberOfBedrooms()));
+        appendNumeric(builder, "Baños", valueOrNull(param.getNumberOfBathrooms()));
+        appendDictionary(builder, "Tipo de vivienda", param.getType(), translationResolver);
+        appendDictionary(builder, "Mobiliario", param.getFurnishings(), translationResolver);
+        appendBoolean(builder, "Ascensor", param.getElevator());
+        appendDictionary(builder, "Balcón o terraza", param.getBalconyTerrace(), translationResolver);
+        appendDictionary(builder, "Garaje o aparcamiento", param.getGarageParking(), translationResolver);
+        appendDictionary(builder, "Jardín o patio", param.getGardenYard(), translationResolver);
+        appendBoolean(builder, "Piscina", param.getPool());
+        appendBoolean(builder, "Trastero", param.getStoreroom());
+        appendDictionary(builder, "Estado", param.getHousingCondition(), translationResolver);
+        appendDictionary(builder, "Planta", param.getFloor(), translationResolver);
+        appendBoolean(builder, "Aire acondicionado", param.getAirConditioner());
+        appendDictionary(builder, "Calefacción", param.getHeating(), translationResolver);
+        appendDictionary(builder, "Certificado energético", param.getEnergyCertificate(), translationResolver);
+        appendNumeric(builder, "Año de construcción", valueOrNull(param.getYearBuilt()));
+        appendDictionary(builder, "Orientación", param.getOrientation(), translationResolver);
+        return builder.toString().trim();
+    }
+
+    private static void appendLocation(StringBuilder builder, Location location, Map<String, String> translationResolver) {
+        if (location == null || location.getNameKey() == null) {
+            return;
+        }
+        String translated = translationResolver.getOrDefault(location.getNameKey(), location.getNameKey());
+        builder.append("Ubicación: ").append(translated).append('.').append(' ');
+    }
+
+    private static void appendNumeric(StringBuilder builder, String label, String value) {
+        if (value == null) {
+            return;
+        }
+        builder.append(label).append(':').append(' ').append(value).append('.').append(' ');
+    }
+
+    private static String valueOrNull(Number number) {
+        return number == null ? null : String.valueOf(number);
+    }
+
+    private static void appendDictionary(StringBuilder builder, String label, Object word, Map<String, String> translationResolver) {
+        if (word == null) {
+            return;
+        }
+        String key = null;
+        try {
+            key = (String) word.getClass().getMethod("getKey").invoke(word);
+        } catch (ReflectiveOperationException ignored) {
+            // Если структура изменилась, пропускаем значение.
+        }
+        if (key == null) {
+            return;
+        }
+        String translated = translationResolver.getOrDefault(key, key);
+        builder.append(label).append(':').append(' ').append(translated).append('.').append(' ');
+    }
+
+    private static void appendBoolean(StringBuilder builder, String label, Boolean value) {
+        if (value == null) {
+            return;
+        }
+        builder.append(label).append(':').append(' ').append(Boolean.TRUE.equals(value) ? YES : NO).append('.').append(' ');
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/service/RealEstateMilvusService.java
+++ b/src/main/java/org/garlikoff/restdata/service/RealEstateMilvusService.java
@@ -1,0 +1,581 @@
+package org.garlikoff.restdata.service;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.grpc.DataType;
+import io.milvus.param.R;
+import io.milvus.param.collection.CreateCollectionParam;
+import io.milvus.param.collection.FieldType;
+import io.milvus.param.collection.FlushParam;
+import io.milvus.param.collection.HasCollectionParam;
+import io.milvus.param.collection.LoadCollectionParam;
+import io.milvus.param.dml.InsertParam;
+import io.milvus.param.dml.SearchParam;
+import io.milvus.param.index.CreateIndexParam;
+import io.milvus.param.MetricType;
+import io.milvus.grpc.FlushResponse;
+import io.milvus.response.SearchResultsWrapper;
+import org.garlikoff.restdata.config.MilvusProperties;
+import org.garlikoff.restdata.model.RealEstateObject;
+import org.garlikoff.restdata.model.RealEstateObjectParam;
+import org.garlikoff.restdata.model.TranslationId;
+import org.garlikoff.restdata.repo.RealEstateObjectParamRepository;
+import org.garlikoff.restdata.repo.RealEstateObjectRepository;
+import org.garlikoff.restdata.repo.TranslationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Сервис синхронизации объектов недвижимости с Milvus и выполнения поиска.
+ */
+@Service
+public class RealEstateMilvusService {
+    private static final String FIELD_OBJECT_ID = "object_id";
+    private static final String FIELD_PARAM_ID = "param_id";
+    private static final String FIELD_USER_ID = "user_id";
+    private static final String FIELD_DESCRIPTION = "description";
+
+    private final MilvusServiceClient client;
+    private final MilvusProperties properties;
+    private final RealEstateObjectRepository objectRepository;
+    private final RealEstateObjectParamRepository paramRepository;
+    private final TranslationRepository translationRepository;
+    private final SimpleEmbeddingService embeddingService;
+    private final RealEstateDescriptionBuilder descriptionBuilder;
+
+    public RealEstateMilvusService(MilvusServiceClient client,
+                                   MilvusProperties properties,
+                                   RealEstateObjectRepository objectRepository,
+                                   RealEstateObjectParamRepository paramRepository,
+                                   TranslationRepository translationRepository,
+                                   SimpleEmbeddingService embeddingService,
+                                   RealEstateDescriptionBuilder descriptionBuilder) {
+        this.client = client;
+        this.properties = properties;
+        this.objectRepository = objectRepository;
+        this.paramRepository = paramRepository;
+        this.translationRepository = translationRepository;
+        this.embeddingService = embeddingService;
+        this.descriptionBuilder = descriptionBuilder;
+    }
+
+    /**
+     * Выполняет полную синхронизацию всех объектов недвижимости в Milvus.
+     *
+     * @return количество загруженных записей
+     */
+    @Transactional(readOnly = true)
+    public synchronized int synchronizeAll() {
+        recreateCollection();
+        List<RealEstateObject> objects = streamOf(objectRepository.findAll())
+            .sorted(Comparator.comparing(RealEstateObject::getId))
+            .toList();
+        List<RealEstateObjectParam> params = streamOf(paramRepository.findAll())
+            .sorted(Comparator.comparing(RealEstateObjectParam::getId))
+            .toList();
+        Map<UUID, Deque<RealEstateObjectParam>> paramsByUser = params.stream()
+            .filter(param -> param.getUser() != null)
+            .collect(Collectors.groupingBy(param -> param.getUser().getId(), Collectors.toCollection(ArrayDeque::new)));
+        if (objects.isEmpty()) {
+            return 0;
+        }
+        Set<String> dictionaryKeys = collectDictionaryKeys(params);
+        Map<String, String> translations = loadTranslations(dictionaryKeys);
+        List<RealEstateVectorRecord> records = new ArrayList<>();
+        for (RealEstateObject object : objects) {
+            if (object.getUser() == null) {
+                continue;
+            }
+            Deque<RealEstateObjectParam> queue = paramsByUser.get(object.getUser().getId());
+            if (queue == null || queue.isEmpty()) {
+                continue;
+            }
+            RealEstateObjectParam param = queue.pollFirst();
+            if (param == null) {
+                continue;
+            }
+            String description = descriptionBuilder.buildDescription(param, translations);
+            if (description.length() > properties.getDescriptionMaxLength()) {
+                description = description.substring(0, properties.getDescriptionMaxLength()).trim();
+            }
+            float[] embedding = embeddingService.embed(description, properties.getDimension());
+            UUID userId = Optional.ofNullable(param.getUser())
+                .map(user -> user.getId())
+                .orElseGet(() -> Optional.ofNullable(object.getUser()).map(user -> user.getId()).orElse(null));
+            records.add(new RealEstateVectorRecord(object.getId(), param.getId(), userId, description, embedding));
+        }
+        if (records.isEmpty()) {
+            return 0;
+        }
+        insertRecords(records);
+        return records.size();
+    }
+
+    /**
+     * Выполняет поиск объектов по текстовому запросу.
+     *
+     * @param query текст запроса
+     * @param limit максимальное число результатов
+     * @return найденные объекты
+     */
+    public synchronized List<RealEstateSearchResult> search(String query, int limit) {
+        ensureCollection();
+        if (query == null || query.isBlank()) {
+            return Collections.emptyList();
+        }
+        float[] vector = embeddingService.embed(query, properties.getDimension());
+        List<List<Float>> vectors = List.of(toList(vector));
+        SearchParam.Builder searchBuilder = SearchParam.newBuilder();
+        searchBuilder = apply(searchBuilder, String.class, properties.getCollection(),
+            "withCollectionName", "withCollection");
+        searchBuilder = apply(searchBuilder, MetricType.class, resolveMetricType(),
+            "withMetricType");
+        searchBuilder = apply(searchBuilder, List.class,
+            List.of(FIELD_OBJECT_ID, FIELD_PARAM_ID, FIELD_USER_ID, FIELD_DESCRIPTION),
+            "withOutFields", "withOutputFields");
+        searchBuilder = apply(searchBuilder, int.class, Math.max(1, limit),
+            "withTopK", "withTopk");
+        searchBuilder = apply(searchBuilder, List.class, vectors,
+            "withVectors");
+        searchBuilder = apply(searchBuilder, String.class, properties.getVectorField(),
+            "withVectorFieldName", "withVectorField");
+        searchBuilder = apply(searchBuilder, String.class, properties.getSearchParams(),
+            "withParams", "withSearchParams");
+        SearchParam searchParam = searchBuilder.build();
+        io.milvus.param.R<io.milvus.grpc.SearchResults> response = client.search(searchParam);
+        check(response, "search vectors");
+        SearchResultsWrapper wrapper = new SearchResultsWrapper(response.getData().getResults());
+        return extractResults(wrapper);
+    }
+
+    private synchronized void ensureCollection() {
+        HasCollectionParam hasCollectionParam = HasCollectionParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .build();
+        R<Boolean> exists = client.hasCollection(hasCollectionParam);
+        check(exists, "check collection existence");
+        if (Boolean.TRUE.equals(exists.getData())) {
+            return;
+        }
+        createCollection();
+    }
+
+    private synchronized void recreateCollection() {
+        HasCollectionParam hasCollectionParam = HasCollectionParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .build();
+        R<Boolean> exists = client.hasCollection(hasCollectionParam);
+        check(exists, "check collection existence");
+        if (Boolean.TRUE.equals(exists.getData())) {
+            dropCollection();
+        }
+        createCollection();
+    }
+
+    private void dropCollection() {
+        io.milvus.param.collection.DropCollectionParam dropCollectionParam = io.milvus.param.collection.DropCollectionParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .build();
+        R<?> dropResponse = client.dropCollection(dropCollectionParam);
+        check(dropResponse, "drop collection");
+    }
+
+    private void createCollection() {
+        FieldType primary = FieldType.newBuilder()
+            .withName("id")
+            .withDataType(DataType.Int64)
+            .withPrimaryKey(true)
+            .withAutoID(true)
+            .build();
+        FieldType objectId = FieldType.newBuilder()
+            .withName(FIELD_OBJECT_ID)
+            .withDataType(DataType.VarChar)
+            .withMaxLength(64)
+            .build();
+        FieldType paramId = FieldType.newBuilder()
+            .withName(FIELD_PARAM_ID)
+            .withDataType(DataType.VarChar)
+            .withMaxLength(64)
+            .build();
+        FieldType userId = FieldType.newBuilder()
+            .withName(FIELD_USER_ID)
+            .withDataType(DataType.VarChar)
+            .withMaxLength(64)
+            .build();
+        FieldType description = FieldType.newBuilder()
+            .withName(FIELD_DESCRIPTION)
+            .withDataType(DataType.VarChar)
+            .withMaxLength(properties.getDescriptionMaxLength())
+            .build();
+        FieldType vector = FieldType.newBuilder()
+            .withName(properties.getVectorField())
+            .withDataType(DataType.FloatVector)
+            .withDimension(properties.getDimension())
+            .build();
+        CreateCollectionParam.Builder builder = CreateCollectionParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .withDescription("Real estate objects embeddings")
+            .withShardsNum(properties.getShardsNum())
+            .addFieldType(primary)
+            .addFieldType(objectId)
+            .addFieldType(paramId)
+            .addFieldType(userId)
+            .addFieldType(description)
+            .addFieldType(vector);
+        CreateCollectionParam createCollectionParam = builder.build();
+        R<?> createResponse = client.createCollection(createCollectionParam);
+        check(createResponse, "create collection");
+        CreateIndexParam.Builder indexBuilder = CreateIndexParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .withFieldName(properties.getVectorField())
+            .withIndexName(properties.getVectorField() + "_idx")
+            .withMetricType(resolveMetricType())
+            .withExtraParam(properties.getIndexParams());
+        applyIndexType(indexBuilder);
+        CreateIndexParam indexParam = indexBuilder.build();
+        R<?> indexResponse = client.createIndex(indexParam);
+        check(indexResponse, "create index");
+    }
+
+    private void insertRecords(List<RealEstateVectorRecord> records) {
+        List<String> objectIds = new ArrayList<>(records.size());
+        List<String> paramIds = new ArrayList<>(records.size());
+        List<String> userIds = new ArrayList<>(records.size());
+        List<String> descriptions = new ArrayList<>(records.size());
+        List<List<Float>> vectors = new ArrayList<>(records.size());
+        for (RealEstateVectorRecord record : records) {
+            objectIds.add(record.objectId().toString());
+            paramIds.add(record.paramId().toString());
+            userIds.add(record.userId() != null ? record.userId().toString() : "");
+            descriptions.add(record.description());
+            vectors.add(toList(record.vector()));
+        }
+        List<InsertParam.Field> fields = List.of(
+            new InsertParam.Field(FIELD_OBJECT_ID, objectIds),
+            new InsertParam.Field(FIELD_PARAM_ID, paramIds),
+            new InsertParam.Field(FIELD_USER_ID, userIds),
+            new InsertParam.Field(FIELD_DESCRIPTION, descriptions),
+            new InsertParam.Field(properties.getVectorField(), vectors)
+        );
+        InsertParam insertParam = InsertParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .withFields(fields)
+            .build();
+        R<io.milvus.grpc.MutationResult> insertResponse = client.insert(insertParam);
+        check(insertResponse, "insert records");
+        R<FlushResponse> flushResponse = client.flush(FlushParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .build());
+        check(flushResponse, "flush collection");
+        R<?> loadResponse = client.loadCollection(LoadCollectionParam.newBuilder()
+            .withCollectionName(properties.getCollection())
+            .build());
+        check(loadResponse, "load collection");
+    }
+
+    private Map<String, String> loadTranslations(Set<String> keys) {
+        if (keys.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<TranslationId> ids = keys.stream()
+            .map(key -> {
+                TranslationId id = new TranslationId();
+                id.setWordKey(key);
+                id.setLanguageKey(properties.getLanguage());
+                return id;
+            })
+            .toList();
+        Map<String, String> translations = new HashMap<>();
+        translationRepository.findAllById(ids).forEach(translation ->
+            translations.put(translation.getId().getWordKey(), translation.getValue())
+        );
+        return translations;
+    }
+
+    private Set<String> collectDictionaryKeys(List<RealEstateObjectParam> params) {
+        Set<String> keys = new HashSet<>();
+        for (RealEstateObjectParam param : params) {
+            if (param.getLocation() != null && param.getLocation().getNameKey() != null) {
+                keys.add(param.getLocation().getNameKey());
+            }
+            collectWordKey(param.getType(), keys);
+            collectWordKey(param.getFurnishings(), keys);
+            collectWordKey(param.getBalconyTerrace(), keys);
+            collectWordKey(param.getGarageParking(), keys);
+            collectWordKey(param.getGardenYard(), keys);
+            collectWordKey(param.getHousingCondition(), keys);
+            collectWordKey(param.getFloor(), keys);
+            collectWordKey(param.getHeating(), keys);
+            collectWordKey(param.getEnergyCertificate(), keys);
+            collectWordKey(param.getOrientation(), keys);
+        }
+        return keys;
+    }
+
+    private static void collectWordKey(Object word, Set<String> keys) {
+        if (word == null) {
+            return;
+        }
+        try {
+            String key = (String) word.getClass().getMethod("getKey").invoke(word);
+            if (key != null) {
+                keys.add(key);
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // нет доступа к ключу слова
+        }
+    }
+
+    private static List<Float> toList(float[] vector) {
+        List<Float> list = new ArrayList<>(vector.length);
+        for (float value : vector) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static UUID parseUuid(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString();
+        if (text.isBlank()) {
+            return null;
+        }
+        return UUID.fromString(text);
+    }
+
+    private List<RealEstateSearchResult> extractResults(SearchResultsWrapper wrapper) {
+        List<RealEstateSearchResult> results = tryExtractRowRecords(wrapper);
+        if (!results.isEmpty()) {
+            return results;
+        }
+        return extractFromColumns(wrapper);
+    }
+
+    private List<RealEstateSearchResult> tryExtractRowRecords(SearchResultsWrapper wrapper) {
+        try {
+            Method getRowRecords = wrapper.getClass().getMethod("getRowRecords");
+            Object rawRows = getRowRecords.invoke(wrapper);
+            if (!(rawRows instanceof List<?> rows) || rows.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<RealEstateSearchResult> results = new ArrayList<>(rows.size());
+            for (Object row : rows) {
+                Object objectIdValue = invokeRow(row, "getFieldValue", FIELD_OBJECT_ID);
+                Object paramIdValue = invokeRow(row, "getFieldValue", FIELD_PARAM_ID);
+                Object userIdValue = invokeRow(row, "getFieldValue", FIELD_USER_ID);
+                Object descriptionValue = invokeRow(row, "getFieldValue", FIELD_DESCRIPTION);
+                Object scoreValue = invokeRow(row, "getScore");
+                float score = scoreValue instanceof Number number ? number.floatValue() : 0F;
+                UUID objectId = parseUuid(objectIdValue);
+                UUID paramId = parseUuid(paramIdValue);
+                UUID userId = parseUuid(userIdValue);
+                String description = descriptionValue != null ? descriptionValue.toString() : "";
+                results.add(new RealEstateSearchResult(objectId, paramId, userId, score, description));
+            }
+            return results;
+        } catch (ReflectiveOperationException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    private List<RealEstateSearchResult> extractFromColumns(SearchResultsWrapper wrapper) {
+        List<?> objectIds = getFieldData(wrapper, FIELD_OBJECT_ID);
+        List<?> paramIds = getFieldData(wrapper, FIELD_PARAM_ID);
+        List<?> userIds = getFieldData(wrapper, FIELD_USER_ID);
+        List<?> descriptions = getFieldData(wrapper, FIELD_DESCRIPTION);
+        List<Float> scores = getScores(wrapper);
+        int rowCount = Math.max(Math.max(objectIds.size(), paramIds.size()), Math.max(userIds.size(), descriptions.size()));
+        rowCount = Math.max(rowCount, scores.size());
+        if (rowCount == 0) {
+            int inferred = getRowCount(wrapper);
+            rowCount = Math.max(rowCount, inferred);
+        }
+        if (rowCount == 0) {
+            return Collections.emptyList();
+        }
+        List<RealEstateSearchResult> results = new ArrayList<>(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            UUID objectId = parseUuid(getValue(objectIds, i));
+            UUID paramId = parseUuid(getValue(paramIds, i));
+            UUID userId = parseUuid(getValue(userIds, i));
+            Object descriptionValue = getValue(descriptions, i);
+            String description = descriptionValue != null ? descriptionValue.toString() : "";
+            float score = i < scores.size() ? scores.get(i) : 0F;
+            results.add(new RealEstateSearchResult(objectId, paramId, userId, score, description));
+        }
+        return results;
+    }
+
+    private static Object invokeRow(Object row, String method, Object... args) throws ReflectiveOperationException {
+        Class<?>[] types = new Class<?>[args.length];
+        for (int i = 0; i < args.length; i++) {
+            types[i] = args[i] != null ? args[i].getClass() : Object.class;
+        }
+        try {
+            Method m = row.getClass().getMethod(method, types);
+            return m.invoke(row, args);
+        } catch (NoSuchMethodException ex) {
+            Method m = row.getClass().getMethod(method);
+            return m.invoke(row);
+        }
+    }
+
+    private static List<?> getFieldData(SearchResultsWrapper wrapper, String field) {
+        try {
+            Method method = wrapper.getClass().getMethod("getFieldData", String.class);
+            Object data = method.invoke(wrapper, field);
+            if (data instanceof List<?> list) {
+                return list;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // метод может отсутствовать в текущей версии SDK
+        }
+        return Collections.emptyList();
+    }
+
+    private static int getRowCount(SearchResultsWrapper wrapper) {
+        try {
+            Method method = wrapper.getClass().getMethod("getRowCount");
+            Object count = method.invoke(wrapper);
+            if (count instanceof Number number) {
+                return number.intValue();
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // метод может отсутствовать
+        }
+        return 0;
+    }
+
+    private static Object getValue(List<?> list, int index) {
+        if (list == null || list.isEmpty() || index < 0 || index >= list.size()) {
+            return null;
+        }
+        return list.get(index);
+    }
+
+    private static List<Float> getScores(SearchResultsWrapper wrapper) {
+        try {
+            Method getIdScore = wrapper.getClass().getMethod("getIDScore", int.class);
+            Object idScore = getIdScore.invoke(wrapper, 0);
+            if (idScore == null) {
+                return Collections.emptyList();
+            }
+            Method getScores = idScore.getClass().getMethod("getScores");
+            Object rawScores = getScores.invoke(idScore);
+            if (rawScores instanceof List<?> list) {
+                List<Float> scores = new ArrayList<>(list.size());
+                for (Object value : list) {
+                    if (value instanceof Number number) {
+                        scores.add(number.floatValue());
+                    } else if (value != null) {
+                        try {
+                            scores.add(Float.parseFloat(value.toString()));
+                        } catch (NumberFormatException ignored) {
+                            scores.add(0F);
+                        }
+                    } else {
+                        scores.add(0F);
+                    }
+                }
+                return scores;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // метод может отсутствовать
+        }
+        return Collections.emptyList();
+    }
+
+    private static SearchParam.Builder apply(SearchParam.Builder builder, Class<?> parameterType, Object value,
+                                             String... methodNames) {
+        for (String methodName : methodNames) {
+            try {
+                Method method = builder.getClass().getMethod(methodName, parameterType);
+                Object result = method.invoke(builder, value);
+                if (result instanceof SearchParam.Builder resultBuilder) {
+                    return resultBuilder;
+                }
+                return builder;
+            } catch (NoSuchMethodException ignored) {
+                // пробуем следующий кандидат
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException("Failed to invoke Milvus builder method '" + methodName + "'", ex);
+            }
+        }
+        throw new IllegalStateException("Milvus SDK builder does not support methods " + Arrays.toString(methodNames));
+    }
+
+    private void applyIndexType(CreateIndexParam.Builder builder) {
+        if (builder == null) {
+            return;
+        }
+        if (!setIndexType(builder, properties.getIndexType())) {
+            setIndexType(builder, "IVF_FLAT");
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private boolean setIndexType(CreateIndexParam.Builder builder, String type) {
+        if (type == null || type.isBlank()) {
+            return false;
+        }
+        try {
+            Class<?> indexTypeClass = Class.forName("io.milvus.param.index.IndexType");
+            if (!Enum.class.isAssignableFrom(indexTypeClass)) {
+                return false;
+            }
+            Enum value = Enum.valueOf((Class<? extends Enum>) indexTypeClass.asSubclass(Enum.class), type.toUpperCase(Locale.ROOT));
+            builder.getClass().getMethod("withIndexType", indexTypeClass).invoke(builder, value);
+            return true;
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        } catch (ReflectiveOperationException ignored) {
+            return false;
+        }
+    }
+
+    private MetricType resolveMetricType() {
+        try {
+            return MetricType.valueOf(properties.getMetricType().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return MetricType.COSINE;
+        }
+    }
+
+    private static <T> java.util.stream.Stream<T> streamOf(Iterable<T> iterable) {
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    private static <T> void check(R<T> response, String action) {
+        if (response.getStatus() != R.Status.Success.getCode()) {
+            throw new IllegalStateException("Failed to " + action + ": " + response.getMessage());
+        }
+    }
+
+    /**
+     * DTO результата поиска по Milvus.
+     */
+    public record RealEstateSearchResult(UUID objectId, UUID paramId, UUID userId, float score, String description) {
+    }
+
+    private record RealEstateVectorRecord(UUID objectId, UUID paramId, UUID userId, String description, float[] vector) {
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/service/SimpleEmbeddingService.java
+++ b/src/main/java/org/garlikoff/restdata/service/SimpleEmbeddingService.java
@@ -1,0 +1,50 @@
+package org.garlikoff.restdata.service;
+
+import org.springframework.stereotype.Component;
+
+import java.text.Normalizer;
+import java.util.Locale;
+
+/**
+ * Простейший генератор векторных представлений текста.
+ */
+@Component
+public class SimpleEmbeddingService {
+
+    /**
+     * Формирует нормализованный вектор фиксированной размерности из текстового описания.
+     *
+     * @param text       исходный текст
+     * @param dimension  требуемая размерность вектора
+     * @return нормализованный вектор признаков
+     */
+    public float[] embed(String text, int dimension) {
+        if (dimension <= 0) {
+            throw new IllegalArgumentException("Vector dimension must be positive");
+        }
+        float[] vector = new float[dimension];
+        if (text == null || text.isBlank()) {
+            vector[0] = 1f;
+            return vector;
+        }
+        String normalized = Normalizer.normalize(text, Normalizer.Form.NFKD)
+            .toLowerCase(Locale.ROOT);
+        for (int i = 0; i < normalized.length(); i++) {
+            int index = normalized.charAt(i) % dimension;
+            vector[index] += 1f;
+        }
+        float norm = 0f;
+        for (float value : vector) {
+            norm += value * value;
+        }
+        norm = (float) Math.sqrt(norm);
+        if (norm == 0f) {
+            vector[0] = 1f;
+            return vector;
+        }
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] /= norm;
+        }
+        return vector;
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/web/RealEstateExportController.java
+++ b/src/main/java/org/garlikoff/restdata/web/RealEstateExportController.java
@@ -1,0 +1,33 @@
+package org.garlikoff.restdata.web;
+
+import org.garlikoff.restdata.service.RealEstateMilvusService;
+import org.garlikoff.restdata.web.dto.RealEstateExportResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Контроллер, запускающий выгрузку объектов недвижимости в Milvus.
+ */
+@RestController
+@RequestMapping("/api/vector/real-estate")
+public class RealEstateExportController {
+
+    private final RealEstateMilvusService milvusService;
+
+    public RealEstateExportController(RealEstateMilvusService milvusService) {
+        this.milvusService = milvusService;
+    }
+
+    /**
+     * Выполняет полную синхронизацию объектов недвижимости в Milvus.
+     *
+     * @return количество обработанных объектов
+     */
+    @PostMapping("/export")
+    public ResponseEntity<RealEstateExportResponse> export() {
+        int total = milvusService.synchronizeAll();
+        return ResponseEntity.ok(new RealEstateExportResponse(total));
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/web/RealEstateSearchController.java
+++ b/src/main/java/org/garlikoff/restdata/web/RealEstateSearchController.java
@@ -1,0 +1,48 @@
+package org.garlikoff.restdata.web;
+
+import org.garlikoff.restdata.service.RealEstateMilvusService;
+import org.garlikoff.restdata.service.RealEstateMilvusService.RealEstateSearchResult;
+import org.garlikoff.restdata.web.dto.RealEstateSearchResponse;
+import org.garlikoff.restdata.web.dto.RealEstateSearchResultDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Контроллер, выполняющий поиск объектов недвижимости по запросу.
+ */
+@RestController
+@RequestMapping("/api/vector/real-estate")
+public class RealEstateSearchController {
+
+    private final RealEstateMilvusService milvusService;
+
+    public RealEstateSearchController(RealEstateMilvusService milvusService) {
+        this.milvusService = milvusService;
+    }
+
+    /**
+     * Выполняет поиск в Milvus по текстовому запросу.
+     *
+     * @param query текст поискового запроса
+     * @param limit максимальное количество результатов
+     * @return подходящие объекты
+     */
+    @GetMapping("/search")
+    public ResponseEntity<RealEstateSearchResponse> search(@RequestParam("query") String query,
+                                                           @RequestParam(value = "limit", defaultValue = "10") int limit) {
+        List<RealEstateSearchResultDto> results = milvusService.search(query, limit).stream()
+            .map(this::toDto)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(new RealEstateSearchResponse(results));
+    }
+
+    private RealEstateSearchResultDto toDto(RealEstateSearchResult result) {
+        return new RealEstateSearchResultDto(result.objectId(), result.paramId(), result.userId(), result.score(), result.description());
+    }
+}

--- a/src/main/java/org/garlikoff/restdata/web/dto/RealEstateExportResponse.java
+++ b/src/main/java/org/garlikoff/restdata/web/dto/RealEstateExportResponse.java
@@ -1,0 +1,7 @@
+package org.garlikoff.restdata.web.dto;
+
+/**
+ * Ответ на запрос экспорта объектов недвижимости в Milvus.
+ */
+public record RealEstateExportResponse(int totalExported) {
+}

--- a/src/main/java/org/garlikoff/restdata/web/dto/RealEstateSearchResponse.java
+++ b/src/main/java/org/garlikoff/restdata/web/dto/RealEstateSearchResponse.java
@@ -1,0 +1,9 @@
+package org.garlikoff.restdata.web.dto;
+
+import java.util.List;
+
+/**
+ * Ответ поиска объектов недвижимости по векторной базе данных.
+ */
+public record RealEstateSearchResponse(List<RealEstateSearchResultDto> results) {
+}

--- a/src/main/java/org/garlikoff/restdata/web/dto/RealEstateSearchResultDto.java
+++ b/src/main/java/org/garlikoff/restdata/web/dto/RealEstateSearchResultDto.java
@@ -1,0 +1,9 @@
+package org.garlikoff.restdata.web.dto;
+
+import java.util.UUID;
+
+/**
+ * DTO результата поиска объекта недвижимости.
+ */
+public record RealEstateSearchResultDto(UUID objectId, UUID paramId, UUID userId, float score, String description) {
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,3 +57,18 @@ management:
 logging:
   level:
     org.springframework.security: DEBUG
+
+milvus:
+  host: localhost
+  port: 19530
+  database: default
+  collection: real_estate_objects
+  vector-field: embedding
+  dimension: 256
+  index-type: IVF_FLAT
+  index-params: '{"nlist":1024}'
+  search-params: '{"nprobe":16}'
+  metric-type: COSINE
+  shards-num: 2
+  description-max-length: 1024
+  language: es

--- a/src/main/resources/liquibase/changes/01-create-tables.xml
+++ b/src/main/resources/liquibase/changes/01-create-tables.xml
@@ -62,13 +62,18 @@
             <column name="type" type="VARCHAR"/>
             <column name="furnishings" type="VARCHAR"/>
             <column name="elevator" type="BOOLEAN"/>
-            <column name="balcony" type="BOOLEAN"/>
-            <column name="garage" type="BOOLEAN"/>
-            <column name="courtyard" type="BOOLEAN"/>
+            <column name="balcony_terrace" type="VARCHAR"/>
+            <column name="garage_parking" type="VARCHAR"/>
+            <column name="garden_yard" type="VARCHAR"/>
             <column name="pool" type="BOOLEAN"/>
             <column name="storeroom" type="BOOLEAN"/>
-            <column name="floor" type="INT"/>
+            <column name="housing_condition" type="VARCHAR"/>
+            <column name="floor" type="VARCHAR"/>
             <column name="air_conditioner" type="BOOLEAN"/>
+            <column name="heating" type="VARCHAR"/>
+            <column name="energy_certificate" type="VARCHAR"/>
+            <column name="year_built" type="INT"/>
+            <column name="orientation" type="VARCHAR"/>
         </createTable>
 
         <createTable tableName="rental_claim">
@@ -163,8 +168,25 @@
         <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="location"
                                  constraintName="real_estate_object_param_location_fk" referencedTableName="location" referencedColumnNames="id"/>
         <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="type"
-                                 constraintName="real_estate_object_param_word_fk" referencedTableName="word" referencedColumnNames="key"/>
-
+                                 constraintName="real_estate_object_param_type_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="furnishings"
+                                 constraintName="real_estate_object_param_furnishings_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="balcony_terrace"
+                                 constraintName="real_estate_object_param_balcony_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="garage_parking"
+                                 constraintName="real_estate_object_param_parking_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="garden_yard"
+                                 constraintName="real_estate_object_param_garden_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="housing_condition"
+                                 constraintName="real_estate_object_param_condition_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="floor"
+                                 constraintName="real_estate_object_param_floor_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="heating"
+                                 constraintName="real_estate_object_param_heating_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="energy_certificate"
+                                 constraintName="real_estate_object_param_energy_certificate_word_fk" referencedTableName="word" referencedColumnNames="key"/>
+        <addForeignKeyConstraint baseTableName="real_estate_object_param" baseColumnNames="orientation"
+                                 constraintName="real_estate_object_param_orientation_word_fk" referencedTableName="word" referencedColumnNames="key"/>
         <addForeignKeyConstraint baseTableName="rental_claim" baseColumnNames="user"
                                  constraintName="rental_claim_user_fk" referencedTableName="user" referencedColumnNames="id"/>
 

--- a/src/main/resources/liquibase/changes/03-load-real-estate-params.xml
+++ b/src/main/resources/liquibase/changes/03-load-real-estate-params.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="3" author="garlikoff">
+        <comment>Заполнение справочников, пользователей и тестовых данных по объектам недвижимости.</comment>
+        <sql>
+            INSERT INTO word (key) VALUES
+                ('HOUSING_TYPE_APARTMENT'),
+                ('HOUSING_TYPE_HOUSE'),
+                ('HOUSING_TYPE_ROOM'),
+                ('FURNISHING_FULL'),
+                ('FURNISHING_PARTIAL'),
+                ('FURNISHING_NONE'),
+                ('BALCONY_BALCONY'),
+                ('BALCONY_TERRACE'),
+                ('BALCONY_NONE'),
+                ('PARKING_GARAGE'),
+                ('PARKING_PARKING'),
+                ('PARKING_NONE'),
+                ('GARDEN_GARDEN'),
+                ('GARDEN_YARD'),
+                ('GARDEN_NONE'),
+                ('CONDITION_NEW'),
+                ('CONDITION_RENOVATED'),
+                ('CONDITION_GOOD'),
+                ('CONDITION_NEEDS_RENOVATION'),
+                ('FLOOR_SOTANO'),
+                ('FLOOR_SEMISOTANO'),
+                ('FLOOR_PLANTA_BAJA'),
+                ('FLOOR_ENTREPLANTA'),
+                ('FLOOR_PRINCIPAL'),
+                ('FLOOR_PRIMERO'),
+                ('FLOOR_SEGUNDO'),
+                ('FLOOR_TERCERO'),
+                ('FLOOR_ATICO'),
+                ('FLOOR_SOBREATICO'),
+                ('FLOOR_BUHARDILLA'),
+                ('HEATING_GAS'),
+                ('HEATING_ELECTRIC'),
+                ('HEATING_NONE'),
+                ('ENERGY_CLASS_A'),
+                ('ENERGY_CLASS_B'),
+                ('ENERGY_CLASS_C'),
+                ('ENERGY_CLASS_D'),
+                ('ENERGY_CLASS_E'),
+                ('ENERGY_CLASS_F'),
+                ('ENERGY_CLASS_G'),
+                ('ORIENTATION_NORTH'),
+                ('ORIENTATION_SOUTH'),
+                ('ORIENTATION_WEST'),
+                ('ORIENTATION_EAST')
+            ON CONFLICT (key) DO NOTHING;
+        </sql>
+        <sql>
+            INSERT INTO translation (word_key, language_key, value) VALUES
+                ('HOUSING_TYPE_APARTMENT', 'es', 'Apartamento'),
+                ('HOUSING_TYPE_APARTMENT', 'en', 'Apartment'),
+                ('HOUSING_TYPE_APARTMENT', 'ru', 'Квартира'),
+                ('HOUSING_TYPE_HOUSE', 'es', 'Casa'),
+                ('HOUSING_TYPE_HOUSE', 'en', 'House'),
+                ('HOUSING_TYPE_HOUSE', 'ru', 'Дом'),
+                ('HOUSING_TYPE_ROOM', 'es', 'Habitación'),
+                ('HOUSING_TYPE_ROOM', 'en', 'Room'),
+                ('HOUSING_TYPE_ROOM', 'ru', 'Комната'),
+                ('FURNISHING_FULL', 'es', 'Amueblado'),
+                ('FURNISHING_FULL', 'en', 'Furnished'),
+                ('FURNISHING_FULL', 'ru', 'Меблировано'),
+                ('FURNISHING_PARTIAL', 'es', 'Parcialmente amueblado'),
+                ('FURNISHING_PARTIAL', 'en', 'Partially furnished'),
+                ('FURNISHING_PARTIAL', 'ru', 'Частично меблировано'),
+                ('FURNISHING_NONE', 'es', 'Sin amueblar'),
+                ('FURNISHING_NONE', 'en', 'Unfurnished'),
+                ('FURNISHING_NONE', 'ru', 'Без мебели'),
+                ('BALCONY_BALCONY', 'es', 'Balcón'),
+                ('BALCONY_BALCONY', 'en', 'Balcony'),
+                ('BALCONY_BALCONY', 'ru', 'Балкон'),
+                ('BALCONY_TERRACE', 'es', 'Terraza'),
+                ('BALCONY_TERRACE', 'en', 'Terrace'),
+                ('BALCONY_TERRACE', 'ru', 'Терраса'),
+                ('BALCONY_NONE', 'es', 'Sin balcón'),
+                ('BALCONY_NONE', 'en', 'No balcony'),
+                ('BALCONY_NONE', 'ru', 'Без балкона'),
+                ('PARKING_GARAGE', 'es', 'Garaje'),
+                ('PARKING_GARAGE', 'en', 'Garage'),
+                ('PARKING_GARAGE', 'ru', 'Гараж'),
+                ('PARKING_PARKING', 'es', 'Aparcamiento'),
+                ('PARKING_PARKING', 'en', 'Parking'),
+                ('PARKING_PARKING', 'ru', 'Парковка'),
+                ('PARKING_NONE', 'es', 'Sin aparcamiento'),
+                ('PARKING_NONE', 'en', 'No parking'),
+                ('PARKING_NONE', 'ru', 'Без парковки'),
+                ('GARDEN_GARDEN', 'es', 'Jardín'),
+                ('GARDEN_GARDEN', 'en', 'Garden'),
+                ('GARDEN_GARDEN', 'ru', 'Сад'),
+                ('GARDEN_YARD', 'es', 'Patio'),
+                ('GARDEN_YARD', 'en', 'Courtyard'),
+                ('GARDEN_YARD', 'ru', 'Двор'),
+                ('GARDEN_NONE', 'es', 'Sin jardín'),
+                ('GARDEN_NONE', 'en', 'No garden'),
+                ('GARDEN_NONE', 'ru', 'Без сада'),
+                ('CONDITION_NEW', 'es', 'Nuevo'),
+                ('CONDITION_NEW', 'en', 'New'),
+                ('CONDITION_NEW', 'ru', 'Новое'),
+                ('CONDITION_RENOVATED', 'es', 'Reformado'),
+                ('CONDITION_RENOVATED', 'en', 'Renovated'),
+                ('CONDITION_RENOVATED', 'ru', 'Отремонтированное'),
+                ('CONDITION_GOOD', 'es', 'En buen estado'),
+                ('CONDITION_GOOD', 'en', 'Good condition'),
+                ('CONDITION_GOOD', 'ru', 'Хорошее'),
+                ('CONDITION_NEEDS_RENOVATION', 'es', 'Necesita reforma'),
+                ('CONDITION_NEEDS_RENOVATION', 'en', 'Needs renovation'),
+                ('CONDITION_NEEDS_RENOVATION', 'ru', 'Требует ремонта'),
+                ('FLOOR_SOTANO', 'es', 'Sótano'),
+                ('FLOOR_SOTANO', 'en', 'Basement'),
+                ('FLOOR_SOTANO', 'ru', 'Подвал'),
+                ('FLOOR_SEMISOTANO', 'es', 'Semisótano'),
+                ('FLOOR_SEMISOTANO', 'en', 'Semi-basement'),
+                ('FLOOR_SEMISOTANO', 'ru', 'Полуподвал'),
+                ('FLOOR_PLANTA_BAJA', 'es', 'Planta baja'),
+                ('FLOOR_PLANTA_BAJA', 'en', 'Ground floor'),
+                ('FLOOR_PLANTA_BAJA', 'ru', 'Цокольный этаж'),
+                ('FLOOR_ENTREPLANTA', 'es', 'Entreplanta'),
+                ('FLOOR_ENTREPLANTA', 'en', 'Mezzanine'),
+                ('FLOOR_ENTREPLANTA', 'ru', 'Антресоль'),
+                ('FLOOR_PRINCIPAL', 'es', 'Principal'),
+                ('FLOOR_PRINCIPAL', 'en', 'Main floor'),
+                ('FLOOR_PRINCIPAL', 'ru', 'Главный этаж'),
+                ('FLOOR_PRIMERO', 'es', '1º'),
+                ('FLOOR_PRIMERO', 'en', 'First floor'),
+                ('FLOOR_PRIMERO', 'ru', 'Первый этаж'),
+                ('FLOOR_SEGUNDO', 'es', '2º'),
+                ('FLOOR_SEGUNDO', 'en', 'Second floor'),
+                ('FLOOR_SEGUNDO', 'ru', 'Второй этаж'),
+                ('FLOOR_TERCERO', 'es', '3º'),
+                ('FLOOR_TERCERO', 'en', 'Third floor'),
+                ('FLOOR_TERCERO', 'ru', 'Третий этаж'),
+                ('FLOOR_ATICO', 'es', 'Ático'),
+                ('FLOOR_ATICO', 'en', 'Penthouse'),
+                ('FLOOR_ATICO', 'ru', 'Пентхаус'),
+                ('FLOOR_SOBREATICO', 'es', 'Sobreático'),
+                ('FLOOR_SOBREATICO', 'en', 'Upper penthouse'),
+                ('FLOOR_SOBREATICO', 'ru', 'Верхний пентхаус'),
+                ('FLOOR_BUHARDILLA', 'es', 'Buhardilla'),
+                ('FLOOR_BUHARDILLA', 'en', 'Loft'),
+                ('FLOOR_BUHARDILLA', 'ru', 'Мансарда'),
+                ('HEATING_GAS', 'es', 'Calefacción de gas'),
+                ('HEATING_GAS', 'en', 'Gas heating'),
+                ('HEATING_GAS', 'ru', 'Газовое отопление'),
+                ('HEATING_ELECTRIC', 'es', 'Calefacción eléctrica'),
+                ('HEATING_ELECTRIC', 'en', 'Electric heating'),
+                ('HEATING_ELECTRIC', 'ru', 'Электрическое отопление'),
+                ('HEATING_NONE', 'es', 'Sin calefacción'),
+                ('HEATING_NONE', 'en', 'No heating'),
+                ('HEATING_NONE', 'ru', 'Без отопления'),
+                ('ENERGY_CLASS_A', 'es', 'Clase energética A'),
+                ('ENERGY_CLASS_A', 'en', 'Energy class A'),
+                ('ENERGY_CLASS_A', 'ru', 'Энергетический класс A'),
+                ('ENERGY_CLASS_B', 'es', 'Clase energética B'),
+                ('ENERGY_CLASS_B', 'en', 'Energy class B'),
+                ('ENERGY_CLASS_B', 'ru', 'Энергетический класс B'),
+                ('ENERGY_CLASS_C', 'es', 'Clase energética C'),
+                ('ENERGY_CLASS_C', 'en', 'Energy class C'),
+                ('ENERGY_CLASS_C', 'ru', 'Энергетический класс C'),
+                ('ENERGY_CLASS_D', 'es', 'Clase energética D'),
+                ('ENERGY_CLASS_D', 'en', 'Energy class D'),
+                ('ENERGY_CLASS_D', 'ru', 'Энергетический класс D'),
+                ('ENERGY_CLASS_E', 'es', 'Clase energética E'),
+                ('ENERGY_CLASS_E', 'en', 'Energy class E'),
+                ('ENERGY_CLASS_E', 'ru', 'Энергетический класс E'),
+                ('ENERGY_CLASS_F', 'es', 'Clase energética F'),
+                ('ENERGY_CLASS_F', 'en', 'Energy class F'),
+                ('ENERGY_CLASS_F', 'ru', 'Энергетический класс F'),
+                ('ENERGY_CLASS_G', 'es', 'Clase energética G'),
+                ('ENERGY_CLASS_G', 'en', 'Energy class G'),
+                ('ENERGY_CLASS_G', 'ru', 'Энергетический класс G'),
+                ('ORIENTATION_NORTH', 'es', 'Norte'),
+                ('ORIENTATION_NORTH', 'en', 'North'),
+                ('ORIENTATION_NORTH', 'ru', 'Север'),
+                ('ORIENTATION_SOUTH', 'es', 'Sur'),
+                ('ORIENTATION_SOUTH', 'en', 'South'),
+                ('ORIENTATION_SOUTH', 'ru', 'Юг'),
+                ('ORIENTATION_WEST', 'es', 'Oeste'),
+                ('ORIENTATION_WEST', 'en', 'West'),
+                ('ORIENTATION_WEST', 'ru', 'Запад'),
+                ('ORIENTATION_EAST', 'es', 'Este'),
+                ('ORIENTATION_EAST', 'en', 'East'),
+                ('ORIENTATION_EAST', 'ru', 'Восток')
+            ON CONFLICT (word_key, language_key) DO NOTHING;
+        </sql>
+        <sql>
+            INSERT INTO "user" (is_agency, name)
+            SELECT (gs.i % 4 = 0), 'Usuario ' || gs.i
+            FROM generate_series(1, 20) AS gs(i);
+        </sql>
+        <sql>
+            WITH ordered_users AS (
+                SELECT id,
+                       ROW_NUMBER() OVER (ORDER BY name) AS rn
+                FROM "user"
+                WHERE name LIKE 'Usuario %'
+            )
+            INSERT INTO real_estate_object (user_id)
+            SELECT u.id
+            FROM generate_series(1, 1000) AS s(i)
+            JOIN ordered_users u ON u.rn = ((s.i - 1) % 20) + 1;
+        </sql>
+        <sql>
+            WITH numbered_objects AS (
+                SELECT id AS real_estate_object_id,
+                       user_id,
+                       ROW_NUMBER() OVER (ORDER BY id) AS rn
+                FROM real_estate_object
+                WHERE user_id IN (SELECT id FROM "user" WHERE name LIKE 'Usuario %')
+            ),
+            location_pool AS (
+                SELECT array_agg(id ORDER BY id) AS ids
+                FROM location
+            ),
+            series AS (
+                SELECT s.i,
+                       no.user_id
+                FROM generate_series(1, 1000) AS s(i)
+                JOIN numbered_objects no ON no.rn = s.i
+            )
+            INSERT INTO real_estate_object_param (
+                user_id,
+                location,
+                area,
+                number_of_bedrooms,
+                number_of_bathrooms,
+                type,
+                furnishings,
+                elevator,
+                balcony_terrace,
+                garage_parking,
+                garden_yard,
+                pool,
+                storeroom,
+                housing_condition,
+                floor,
+                air_conditioner,
+                heating,
+                energy_certificate,
+                year_built,
+                orientation
+            )
+            SELECT
+                series.user_id,
+                location_pool.ids[((series.i - 1) % array_length(location_pool.ids, 1)) + 1],
+                ROUND(45 + (series.i % 120) + ((series.i % 100) / 100.0), 2),
+                (series.i % 6) + 1,
+                CASE (series.i % 3)
+                    WHEN 0 THEN 1
+                    WHEN 1 THEN 2
+                    ELSE 3
+                END,
+                (ARRAY['HOUSING_TYPE_APARTMENT','HOUSING_TYPE_HOUSE','HOUSING_TYPE_ROOM'])[(series.i % 3) + 1],
+                (ARRAY['FURNISHING_FULL','FURNISHING_PARTIAL','FURNISHING_NONE'])[(series.i % 3) + 1],
+                (series.i % 2 = 0),
+                (ARRAY['BALCONY_BALCONY','BALCONY_TERRACE','BALCONY_NONE'])[(series.i % 3) + 1],
+                (ARRAY['PARKING_GARAGE','PARKING_PARKING','PARKING_NONE'])[(series.i % 3) + 1],
+                (ARRAY['GARDEN_GARDEN','GARDEN_YARD','GARDEN_NONE'])[(series.i % 3) + 1],
+                (series.i % 5 = 0),
+                (series.i % 4 = 0),
+                (ARRAY['CONDITION_NEW','CONDITION_RENOVATED','CONDITION_GOOD','CONDITION_NEEDS_RENOVATION'])[(series.i % 4) + 1],
+                (ARRAY['FLOOR_SOTANO','FLOOR_SEMISOTANO','FLOOR_PLANTA_BAJA','FLOOR_ENTREPLANTA','FLOOR_PRINCIPAL','FLOOR_PRIMERO','FLOOR_SEGUNDO','FLOOR_TERCERO','FLOOR_ATICO','FLOOR_SOBREATICO','FLOOR_BUHARDILLA'])[(series.i % 11) + 1],
+                (series.i % 2 = 0),
+                (ARRAY['HEATING_GAS','HEATING_ELECTRIC','HEATING_NONE'])[(series.i % 3) + 1],
+                (ARRAY['ENERGY_CLASS_A','ENERGY_CLASS_B','ENERGY_CLASS_C','ENERGY_CLASS_D','ENERGY_CLASS_E','ENERGY_CLASS_F','ENERGY_CLASS_G'])[(series.i % 7) + 1],
+                1950 + (series.i % 70),
+                (ARRAY['ORIENTATION_NORTH','ORIENTATION_SOUTH','ORIENTATION_WEST','ORIENTATION_EAST'])[(series.i % 4) + 1]
+            FROM series
+            CROSS JOIN location_pool;
+        </sql>
+        <sql>
+            WITH numbered_objects AS (
+                SELECT id AS real_estate_object_id,
+                       user_id,
+                       ROW_NUMBER() OVER (ORDER BY id) AS rn
+                FROM real_estate_object
+                WHERE user_id IN (SELECT id FROM "user" WHERE name LIKE 'Usuario %')
+            ),
+            numbered_params AS (
+                SELECT id AS param_id,
+                       user_id,
+                       location,
+                       type,
+                       ROW_NUMBER() OVER (ORDER BY id) AS rn
+                FROM real_estate_object_param
+                WHERE user_id IN (SELECT id FROM "user" WHERE name LIKE 'Usuario %')
+            )
+            INSERT INTO rental_proposal (
+                real_estate_object_id,
+                "user",
+                location,
+                price,
+                type,
+                pets,
+                proposal_created,
+                proposal_status
+            )
+            SELECT
+                no.real_estate_object_id,
+                no.user_id,
+                np.location,
+                ROUND(500 + ((np.rn * 37) % 2500), 2),
+                np.type,
+                (np.rn % 2 = 0),
+                CURRENT_DATE - (((np.rn - 1) % 30)::int),
+                (ARRAY['ACTIVE','PENDING','CLOSED'])[(np.rn % 3) + 1]
+            FROM numbered_objects no
+            JOIN numbered_params np ON np.rn = no.rn;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/db.changelog-master.xml
+++ b/src/main/resources/liquibase/db.changelog-master.xml
@@ -6,5 +6,6 @@
 
     <include file="changes/01-create-tables.xml" relativeToChangelogFile="true"/>
     <include file="changes/02-load-locations.xml" relativeToChangelogFile="true"/>
+    <include file="changes/03-load-real-estate-params.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/test/java/org/garlikoff/restdata/service/RealEstateMilvusServiceTest.java
+++ b/src/test/java/org/garlikoff/restdata/service/RealEstateMilvusServiceTest.java
@@ -1,0 +1,98 @@
+package org.garlikoff.restdata.service;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.MetricType;
+import io.milvus.param.index.CreateIndexParam;
+import org.garlikoff.restdata.config.MilvusProperties;
+import org.garlikoff.restdata.repo.RealEstateObjectParamRepository;
+import org.garlikoff.restdata.repo.RealEstateObjectRepository;
+import org.garlikoff.restdata.repo.TranslationRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RealEstateMilvusServiceTest {
+
+    @Test
+    void configureIndexBuilderSkipsExtraParamsWhenIndexTypeUnavailable() {
+        MilvusProperties properties = new MilvusProperties();
+        properties.setIndexType("missing_type");
+        properties.setIndexParams("{\"nlist\":256}");
+
+        RealEstateMilvusService service = new RealEstateMilvusService(
+            Mockito.mock(MilvusServiceClient.class),
+            properties,
+            Mockito.mock(RealEstateObjectRepository.class),
+            Mockito.mock(RealEstateObjectParamRepository.class),
+            Mockito.mock(TranslationRepository.class),
+            Mockito.mock(SimpleEmbeddingService.class),
+            Mockito.mock(RealEstateDescriptionBuilder.class)
+        );
+
+        CreateIndexParam.Builder builder = CreateIndexParam.newBuilder()
+            .withFieldName(properties.getVectorField())
+            .withIndexName(properties.getVectorField() + "_idx")
+            .withMetricType(MetricType.COSINE);
+
+        boolean applied = service.configureIndexBuilder(builder);
+
+        assertFalse(applied, "index type should not be applied when enum is unavailable");
+        CreateIndexParam param = builder.build();
+        String extraParam = readExtraParam(param);
+        assertTrue(extraParam == null || extraParam.isBlank(), "extra params must be omitted for AutoIndex");
+    }
+
+    @Test
+    void configureIndexBuilderAppliesExtraParamsWhenIndexTypeAvailable() {
+        MilvusProperties properties = new MilvusProperties();
+        properties.setIndexType("IVF_FLAT");
+        properties.setIndexParams("{\"nlist\":128}");
+
+        RealEstateMilvusService service = new RealEstateMilvusService(
+            Mockito.mock(MilvusServiceClient.class),
+            properties,
+            Mockito.mock(RealEstateObjectRepository.class),
+            Mockito.mock(RealEstateObjectParamRepository.class),
+            Mockito.mock(TranslationRepository.class),
+            Mockito.mock(SimpleEmbeddingService.class),
+            Mockito.mock(RealEstateDescriptionBuilder.class)
+        );
+
+        CreateIndexParam.Builder builder = CreateIndexParam.newBuilder()
+            .withFieldName(properties.getVectorField())
+            .withIndexName(properties.getVectorField() + "_idx")
+            .withMetricType(MetricType.COSINE);
+
+        boolean applied = service.configureIndexBuilder(builder);
+
+        assertTrue(applied, "explicit index type should be applied when available");
+        CreateIndexParam param = builder.build();
+        assertEquals(properties.getIndexParams(), readExtraParam(param),
+            "extra params must match configured value when index type is set");
+    }
+
+    private static String readExtraParam(CreateIndexParam param) {
+        try {
+            Method getter = param.getClass().getMethod("getExtraParam");
+            Object value = getter.invoke(param);
+            return value != null ? value.toString() : null;
+        } catch (NoSuchMethodException ignored) {
+            try {
+                Field field = param.getClass().getDeclaredField("extraParam");
+                field.setAccessible(true);
+                Object value = field.get(param);
+                return value != null ? value.toString() : null;
+            } catch (ReflectiveOperationException reflectionFailure) {
+                throw new IllegalStateException("Unable to inspect extra param", reflectionFailure);
+            }
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Unable to read extra param", ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid importing Milvus classes that are not present by treating service responses generically
- resolve Milvus index type via reflection so collection setup no longer depends on missing SDK enums
- adapt Milvus search construction and result parsing to avoid unavailable SDK helpers while keeping vector search functional

## Testing
- ./gradlew test *(fails: Java 17 toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a171bda0832d894757de8acfcebf